### PR TITLE
Fix Telegram init data parsing

### DIFF
--- a/src/hooks/useTelegramInitData.ts
+++ b/src/hooks/useTelegramInitData.ts
@@ -35,14 +35,11 @@ export function useTelegramInitData(): TelegramInitDataState {
 
             // Try to parse telegram_id from initData.user
             try {
-              const params: Record<string, string> = {};
-              data.split('&').forEach(part => {
-                const [key, value] = part.split('=');
-                params[key] = decodeURIComponent(value);
-              });
+              const params = new URLSearchParams(data);
+              const userParam = params.get('user');
 
-              if (params['user']) {
-                const userObj = JSON.parse(params['user']);
+              if (userParam) {
+                const userObj = JSON.parse(userParam);
                 if (userObj.id) {
                   setTelegramId(userObj.id);
                 }


### PR DESCRIPTION
## Summary
- fix query param parsing in `useTelegramInitData`

## Testing
- `npm run typecheck` *(fails: Cannot find module ...)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ebf6f69a0833296b6384cc048501b